### PR TITLE
westeros-main: Fix return values from openDevice()

### DIFF
--- a/westeros-main.cpp
+++ b/westeros-main.cpp
@@ -566,6 +566,7 @@ int openDevice( std::vector<pollfd> &deviceFds, const char *devPathName )
    if ( fd < 0 )
    {
       printf( "error opening device: %s\n", devPathName );
+      return fd;
    }
    else
    {
@@ -574,26 +575,26 @@ int openDevice( std::vector<pollfd> &deviceFds, const char *devPathName )
       pfd.fd= fd;
       deviceFds.push_back( pfd );
    }
+   return fd;
 }
 
 char *getDevice( const char *path, char *devName )
 {
-   int len, lenDev;
-   char *devPathName= 0;
-   if ( !devName )
-      return devPathName; 
+   int len;
+   char *devicePathName= 0;
+   struct stat buffer;
    len= strlen( devName );
-   
-   devPathName= (char *)malloc( strlen(path)+len+1);
-   if ( devPathName )
+
+   devicePathName= (char *)malloc( strlen(path)+len+1);
+   if ( devicePathName )
    {
-      strcpy( devPathName, path );
-      strcat( devPathName, devName );
-     
-      printf( "found %s\n", devPathName );           
+      strcpy( devicePathName, path );
+      strcat( devicePathName, devName );
    }
-   
-   return devPathName;
+
+   if ( !stat(devicePathName, &buffer) )
+      return devicePathName;
+   return NULL;
 }
 
 void getDevices( std::vector<pollfd> &deviceFds )
@@ -601,24 +602,20 @@ void getDevices( std::vector<pollfd> &deviceFds )
    DIR * dir;
    struct dirent *result;
    char *devPathName;
-   int devNum;
    if ( NULL != (dir = opendir( inputPath )) )
    {
       while( NULL != (result = readdir( dir )) )
       {
-         int len= strlen( result->d_name );
-         if ( (len >= 5) && !strncmp(result->d_name, "event", 5) )
+         if ( (result->d_type != DT_DIR) &&
+             !strncmp(result->d_name, "event", 5) )
          {
-            if ( sscanf( result->d_name, "event%d", &devNum ) == 1 )
+            devPathName= getDevice( inputPath, result->d_name );
+            if ( devPathName )
             {
-               printf(" [%s] ", result->d_name);
-               devPathName= getDevice( inputPath, result->d_name );
-
-               if ( devPathName )
-               {
-                  openDevice( deviceFds, devPathName );
+               if (openDevice( deviceFds, devPathName ) >= 0 )
                   free( devPathName );
-               }
+               else
+                  printf("Could not open device %s\n", devPathName);
             }
          }
       }


### PR DESCRIPTION
- This function was to return an int but we were not returning
  a value.
- Rename shadowed variable devPathName in getDevice()
- stat() the file before using it to ensure that device file exists
  and is valid

This fixes the crashes when building westeros with clang

Signed-off-by: Khem Raj raj.khem@gmail.com
